### PR TITLE
Change lineHighlightBackground

### DIFF
--- a/themes/Gloom.json
+++ b/themes/Gloom.json
@@ -17,7 +17,7 @@
     "editorError.foreground": "#c24038",
     "editorMarkerNavigation.background": "#292A44",
     "editorRuler.foreground": "#333454",
-    "editor.lineHighlightBackground": "#383E4A",
+    "editor.lineHighlightBackground": "#333454",
     "editor.selectionBackground": "#4F528A",
     "editor.selectionHighlightBackground": "#484e5b",
     "editorCursor.foreground": "#94F2E7",


### PR DESCRIPTION
Thanks for porting this theme!

Minor edit to closer resemble the original theme.

Before:
<img width="480" alt="screen shot 2018-02-27 at 10 13 11 pm" src="https://user-images.githubusercontent.com/957488/36772800-7e6b0302-1c0b-11e8-994e-26dd3049c94c.png">

After:
<img width="510" alt="screen shot 2018-02-27 at 10 12 54 pm" src="https://user-images.githubusercontent.com/957488/36772806-8548cd58-1c0b-11e8-94a8-43a33eb46a56.png">

