### PR TITLE
Match JSON colors to original Gloom theme

### DIFF
--- a/themes/Gloom.json
+++ b/themes/Gloom.json
@@ -1028,14 +1028,14 @@
       "name": "[VSCODE-CUSTOM] JSON Property Name",
       "scope": "support.type.property-name.json",
       "settings": {
-        "foreground": "#FF6F9F"
+        "foreground": "#AE81FF"
       }
     },
     {
       "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
       "scope": "support.type.property-name.json punctuation",
       "settings": {
-        "foreground": "#FF6F9F"
+        "foreground": "#6D6DB5"
       }
     },
     {

--- a/themes/Gloom.json
+++ b/themes/Gloom.json
@@ -1025,19 +1025,33 @@
       }
     },
     {
-      "name": "[VSCODE-CUSTOM] JSON Property Name",
+      "name": "JSON Property Names",
       "scope": "support.type.property-name.json",
       "settings": {
         "foreground": "#AE81FF"
       }
     },
     {
-      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "name": "JSON Punctuation for Property Name",
       "scope": "support.type.property-name.json punctuation",
       "settings": {
         "foreground": "#6D6DB5"
       }
     },
+    {
+      "name": "Specific JSON Property values like null",
+      "scope": "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
+      "settings": {
+        "foreground": "#FF6F9F"
+      }
+    },
+    {
+      "name": "punctuation.definition",
+      "scope": "punctuation.definition.string.begin.json ,punctuation.definition.string.end.json",
+      "settings": {
+        "foreground": "#6D6DB5"
+      }
+    }
     {
       "name": "laravel blade tag",
       "scope":

--- a/themes/Gloom.json
+++ b/themes/Gloom.json
@@ -1042,7 +1042,7 @@
       "name": "Specific JSON Property values like null",
       "scope": "meta.structure.dictionary.json meta.structure.dictionary.value constant.language",
       "settings": {
-        "foreground": "#FF6F9F"
+        "foreground": "#ED4781"
       }
     },
     {


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/12901172/41431982-a45c09b4-6fe2-11e8-9b78-a2fb7e986702.png)

# After

![image](https://user-images.githubusercontent.com/12901172/41431986-a8a72792-6fe2-11e8-8310-27d7acad8c43.png)

This is what JSON files in the Atom Gloom theme look like.