### PR TITLE
added transparency to wordHighlightBackground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.1.9
+### Fixed
+* Adjusted wordHighlightBackground to no longer obscure selection
 
 ## 0.1.8
 ### Fixed

--- a/themes/Gloom.json
+++ b/themes/Gloom.json
@@ -23,7 +23,7 @@
     "editorCursor.foreground": "#94F2E7",
     "editor.editor.findMatchBackground": "#42557B",
     "editor.findMatchHighlightBackground": "#314365",
-    "editor.wordHighlightBackground": "#484e5b",
+    "editor.wordHighlightBackground": "#484e5b7b",
     "editor.wordHighlightStrongBackground": "#484e5b",
     "editorGroup.background": "#181A1F",
     "editorGroup.border": "#181A1F",


### PR DESCRIPTION
At the moment the word highlight background draws over the selection background obfuscating the actual selection. Adding transparency to the word highlight background fixes this.